### PR TITLE
Feat: 30분 단위 분봉 데이터 및 주식 업종(코스피, 코스닥) 저장 및 조회 기능 구현 #19

### DIFF
--- a/src/main/java/study/chartservice/chart/application/ChartService.java
+++ b/src/main/java/study/chartservice/chart/application/ChartService.java
@@ -2,9 +2,11 @@ package study.chartservice.chart.application;
 
 import java.util.List;
 import study.chartservice.chart.dto.resp.FluctuationRankDto;
+import study.chartservice.chart.dto.resp.IndexOfStockDto;
 import study.chartservice.chart.dto.resp.InvestorDto;
 import study.chartservice.chart.dto.resp.StockDto;
 import study.chartservice.chart.dto.resp.StockMinDto;
+import study.chartservice.common.StockIndex;
 
 public interface ChartService {
 	List<StockDto> getChartOfDayByStockCode(String stockCode);
@@ -14,5 +16,6 @@ public interface ChartService {
 	StockMinDto getChartOfMinByStockCode(String stockCode);
 	List<InvestorDto> getInvestorByStockCode(String stockCode);
 	List<FluctuationRankDto> getFluctuationRankByDateTimeAndRankStatus(String rankStatus);
+	IndexOfStockDto getIndexOfStockByIscd(StockIndex iscd);
 
 }

--- a/src/main/java/study/chartservice/chart/application/ChartService.java
+++ b/src/main/java/study/chartservice/chart/application/ChartService.java
@@ -4,12 +4,15 @@ import java.util.List;
 import study.chartservice.chart.dto.resp.FluctuationRankDto;
 import study.chartservice.chart.dto.resp.InvestorDto;
 import study.chartservice.chart.dto.resp.StockDto;
+import study.chartservice.chart.dto.resp.StockMinDto;
 
 public interface ChartService {
 	List<StockDto> getChartOfDayByStockCode(String stockCode);
 	List<StockDto> getChartOfWeekByStockCode(String stockCode);
 	List<StockDto> getChartOfMonthByStockCode(String stockCode);
 	List<StockDto> getChartOfYearByStockCode(String stockCode);
+	StockMinDto getChartOfMinByStockCode(String stockCode);
 	List<InvestorDto> getInvestorByStockCode(String stockCode);
 	List<FluctuationRankDto> getFluctuationRankByDateTimeAndRankStatus(String rankStatus);
+
 }

--- a/src/main/java/study/chartservice/chart/application/ChartServiceImp.java
+++ b/src/main/java/study/chartservice/chart/application/ChartServiceImp.java
@@ -8,12 +8,15 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import study.chartservice.chart.domain.FluctuationRank;
 import study.chartservice.chart.domain.Investor;
+import study.chartservice.chart.domain.MinOfStock;
 import study.chartservice.chart.dto.resp.FluctuationRankDto;
 import study.chartservice.chart.dto.resp.InvestorDto;
 import study.chartservice.chart.dto.resp.StockDto;
+import study.chartservice.chart.dto.resp.StockMinDto;
 import study.chartservice.chart.infrastructure.DayOfStockRepository;
 import study.chartservice.chart.infrastructure.FluctuationRankRepository;
 import study.chartservice.chart.infrastructure.InvestorRepository;
+import study.chartservice.chart.infrastructure.MinOfStockRepository;
 import study.chartservice.chart.infrastructure.MonthOfStockRepository;
 import study.chartservice.chart.infrastructure.WeekOfStockRepository;
 import study.chartservice.chart.infrastructure.YearOfStockRepository;
@@ -25,6 +28,7 @@ import study.chartservice.global.common.response.BaseResponseCode;
 public class ChartServiceImp implements ChartService {
 
 	private final ModelMapper modelMapper;
+	private final MinOfStockRepository minOfStockRepository;
 	private final DayOfStockRepository dayOfStockRepository;
 	private final WeekOfStockRepository weekOfStockRepository;
 	private final MonthOfStockRepository monthOfStockRepository;
@@ -62,6 +66,14 @@ public class ChartServiceImp implements ChartService {
 		return yearOfStockRepository.findByStockCode(stockCode).stream()
 				.map(yearOfStock -> modelMapper.map(yearOfStock, StockDto.class))
 				.toList();
+	}
+
+	@Override
+	public StockMinDto getChartOfMinByStockCode(String stockCode) {
+		MinOfStock minOfStock = minOfStockRepository.findByStockCode(stockCode)
+				.orElseThrow(() -> new CustomException(BaseResponseCode.MIN_OF_STOCK_NOT_FOUND));
+
+		return modelMapper.map(minOfStock, StockMinDto.class);
 	}
 
 	@Override

--- a/src/main/java/study/chartservice/chart/application/ChartServiceImp.java
+++ b/src/main/java/study/chartservice/chart/application/ChartServiceImp.java
@@ -7,19 +7,23 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import study.chartservice.chart.domain.FluctuationRank;
+import study.chartservice.chart.domain.IndexOfStock;
 import study.chartservice.chart.domain.Investor;
 import study.chartservice.chart.domain.MinOfStock;
 import study.chartservice.chart.dto.resp.FluctuationRankDto;
+import study.chartservice.chart.dto.resp.IndexOfStockDto;
 import study.chartservice.chart.dto.resp.InvestorDto;
 import study.chartservice.chart.dto.resp.StockDto;
 import study.chartservice.chart.dto.resp.StockMinDto;
 import study.chartservice.chart.infrastructure.DayOfStockRepository;
 import study.chartservice.chart.infrastructure.FluctuationRankRepository;
+import study.chartservice.chart.infrastructure.IndexOfStockRepository;
 import study.chartservice.chart.infrastructure.InvestorRepository;
 import study.chartservice.chart.infrastructure.MinOfStockRepository;
 import study.chartservice.chart.infrastructure.MonthOfStockRepository;
 import study.chartservice.chart.infrastructure.WeekOfStockRepository;
 import study.chartservice.chart.infrastructure.YearOfStockRepository;
+import study.chartservice.common.StockIndex;
 import study.chartservice.global.common.exception.CustomException;
 import study.chartservice.global.common.response.BaseResponseCode;
 
@@ -35,6 +39,7 @@ public class ChartServiceImp implements ChartService {
 	private final YearOfStockRepository yearOfStockRepository;
 	private final InvestorRepository investorRepository;
 	private final FluctuationRankRepository fluctuationRankRepository;
+	private final IndexOfStockRepository indexOfStockRepository;
 
 	@Override
 	@Transactional(readOnly = true)
@@ -105,5 +110,14 @@ public class ChartServiceImp implements ChartService {
 		return fluctuationRanks.stream()
 				.map(fluctuationRank -> modelMapper.map(fluctuationRank, FluctuationRankDto.class))
 				.toList();
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public IndexOfStockDto getIndexOfStockByIscd(StockIndex stockIndex) {
+		IndexOfStock indexOfStock = indexOfStockRepository.findByIscd(stockIndex.name())
+				.orElseThrow(() -> new CustomException(BaseResponseCode.STOCK_INDEX_NOT_FOUND));
+
+		return modelMapper.map(indexOfStock, IndexOfStockDto.class);
 	}
 }

--- a/src/main/java/study/chartservice/chart/domain/IndexOfStock.java
+++ b/src/main/java/study/chartservice/chart/domain/IndexOfStock.java
@@ -1,0 +1,32 @@
+package study.chartservice.chart.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@Document(collection = "indexofstock")
+public class IndexOfStock {
+	@Id
+	private String id;
+	private String iscd;   // 종목 코스피, 코스닥
+	private String dateTime;    // 날짜 시간
+	private String bstp_nmix_prpr; //	업종 지수
+	private String bstp_nmix_prdy_vrss; //	업종 지수 전일 대비
+	private String prdy_vrss_sign; //	전일 대비 부호
+	private String bstp_nmix_prdy_ctrt; //	업종 지수 전일 대비율
+
+	@Builder
+	public IndexOfStock(String iscd, String dateTime, String bstp_nmix_prpr,
+			String bstp_nmix_prdy_vrss,
+			String prdy_vrss_sign, String bstp_nmix_prdy_ctrt) {
+
+		this.iscd = iscd;
+		this.dateTime = dateTime;
+		this.bstp_nmix_prpr = bstp_nmix_prpr;
+		this.bstp_nmix_prdy_vrss = bstp_nmix_prdy_vrss;
+		this.prdy_vrss_sign = prdy_vrss_sign;
+		this.bstp_nmix_prdy_ctrt = bstp_nmix_prdy_ctrt;
+	}
+}

--- a/src/main/java/study/chartservice/chart/domain/MinOfStock.java
+++ b/src/main/java/study/chartservice/chart/domain/MinOfStock.java
@@ -1,0 +1,38 @@
+package study.chartservice.chart.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@Document(collection = "minofstock")
+public class MinOfStock {
+	@Id
+	private String id;
+	private String stockCode; // 주식 코드
+	private String stck_bsop_date; // 주식 영업 일자
+	private String stck_cntg_hour; // 주식 체결 시간
+	private String acml_tr_pbmn; // 누적 거래 대금
+	private String stck_prpr; // 주식 현재가
+	private String stck_oprc;   // 주식 시가2
+	private String stck_hgpr; // 주식 최고가
+	private String stck_lwpr; // 주식 최저가
+	private String cntg_vol; // 체결 거래량
+
+	@Builder
+	public MinOfStock(String stockCode, String stck_bsop_date, String stck_cntg_hour,
+			String acml_tr_pbmn, String stck_prpr, String stck_oprc, String stck_hgpr,
+			String stck_lwpr,
+			String cntg_vol) {
+		this.stockCode = stockCode;
+		this.stck_bsop_date = stck_bsop_date;
+		this.stck_cntg_hour = stck_cntg_hour;
+		this.acml_tr_pbmn = acml_tr_pbmn;
+		this.stck_prpr = stck_prpr;
+		this.stck_oprc = stck_oprc;
+		this.stck_hgpr = stck_hgpr;
+		this.stck_lwpr = stck_lwpr;
+		this.cntg_vol = cntg_vol;
+	}
+}

--- a/src/main/java/study/chartservice/chart/dto/resp/IndexOfStockDto.java
+++ b/src/main/java/study/chartservice/chart/dto/resp/IndexOfStockDto.java
@@ -1,0 +1,14 @@
+package study.chartservice.chart.dto.resp;
+
+import lombok.Getter;
+
+@Getter
+public class IndexOfStockDto {
+
+	private String iscd;   // 종목 코스피, 코스닥
+	private String dateTime;    // 날짜 시간
+	private String bstp_nmix_prpr; //	업종 지수
+	private String bstp_nmix_prdy_vrss; //	업종 지수 전일 대비
+	private String prdy_vrss_sign; //	전일 대비 부호
+	private String bstp_nmix_prdy_ctrt; //	업종 지수 전일 대비율
+}

--- a/src/main/java/study/chartservice/chart/dto/resp/StockMinDto.java
+++ b/src/main/java/study/chartservice/chart/dto/resp/StockMinDto.java
@@ -1,0 +1,13 @@
+package study.chartservice.chart.dto.resp;
+
+import lombok.Getter;
+
+@Getter
+public class StockMinDto {
+	private String stockCode;   // 주식 코드
+	private String stck_cntg_hour; //	주식 체결 시간
+	private String stck_prpr; //	주식 현재가
+	private String stck_hgpr; //	주식 최고가
+	private String stck_lwpr; //	주식 최저가
+	private String cntg_vol; //	체결 거래량
+}

--- a/src/main/java/study/chartservice/chart/infrastructure/IndexOfStockRepository.java
+++ b/src/main/java/study/chartservice/chart/infrastructure/IndexOfStockRepository.java
@@ -1,0 +1,9 @@
+package study.chartservice.chart.infrastructure;
+
+import java.util.Optional;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import study.chartservice.chart.domain.IndexOfStock;
+
+public interface IndexOfStockRepository extends MongoRepository<IndexOfStock, String> {
+	Optional<IndexOfStock> findByIscd(String iscd);
+}

--- a/src/main/java/study/chartservice/chart/infrastructure/MinOfStockRepository.java
+++ b/src/main/java/study/chartservice/chart/infrastructure/MinOfStockRepository.java
@@ -1,0 +1,14 @@
+package study.chartservice.chart.infrastructure;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import study.chartservice.chart.domain.MinOfStock;
+
+public interface MinOfStockRepository extends MongoRepository<MinOfStock, String> {
+	@Query(value = "{}", fields = "{ '_id' : 1 }")
+	List<String> findIdsAll();
+
+	Optional<MinOfStock> findByStockCode(String stockCode);
+}

--- a/src/main/java/study/chartservice/chart/presentation/ChartController.java
+++ b/src/main/java/study/chartservice/chart/presentation/ChartController.java
@@ -11,6 +11,7 @@ import study.chartservice.chart.application.CompanyInfoService;
 import study.chartservice.chart.dto.resp.FluctuationRankDto;
 import study.chartservice.chart.dto.resp.InvestorDto;
 import study.chartservice.chart.dto.resp.StockDto;
+import study.chartservice.chart.dto.resp.StockMinDto;
 import study.chartservice.chart.vo.resp.StockNameVo;
 import study.chartservice.common.StockRankOrder;
 import study.chartservice.global.common.response.BaseResponse;
@@ -31,6 +32,13 @@ public class ChartController {
 		return new BaseResponse<>(
 				modelMapper.map(companyInfoService.getCompanyNameByStockCode(stockCode),
 						StockNameVo.class));
+	}
+
+	@GetMapping("/chart/{stockCode}/price")
+	public BaseResponse<StockMinDto> getChartOfMinByStockCode(
+			@PathVariable("stockCode") String stockCode
+	) {
+		return new BaseResponse<>(chartService.getChartOfMinByStockCode(stockCode));
 	}
 
 	@GetMapping("/chart/{stockCode}/day")

--- a/src/main/java/study/chartservice/chart/presentation/ChartController.java
+++ b/src/main/java/study/chartservice/chart/presentation/ChartController.java
@@ -9,10 +9,12 @@ import org.springframework.web.bind.annotation.RestController;
 import study.chartservice.chart.application.ChartService;
 import study.chartservice.chart.application.CompanyInfoService;
 import study.chartservice.chart.dto.resp.FluctuationRankDto;
+import study.chartservice.chart.dto.resp.IndexOfStockDto;
 import study.chartservice.chart.dto.resp.InvestorDto;
 import study.chartservice.chart.dto.resp.StockDto;
 import study.chartservice.chart.dto.resp.StockMinDto;
 import study.chartservice.chart.vo.resp.StockNameVo;
+import study.chartservice.common.StockIndex;
 import study.chartservice.common.StockRankOrder;
 import study.chartservice.global.common.response.BaseResponse;
 
@@ -86,5 +88,15 @@ public class ChartController {
 	public BaseResponse<List<FluctuationRankDto>> getFluctuationRankByIncrease() {
 		return new BaseResponse<>(chartService.getFluctuationRankByDateTimeAndRankStatus(
 				StockRankOrder.INCREASE.name()));
+	}
+
+	@GetMapping("/mainpage/kospi")
+	public BaseResponse<IndexOfStockDto> getStockIndexKopsi() {
+		return new BaseResponse<>(chartService.getIndexOfStockByIscd(StockIndex.KOSPI));
+	}
+
+	@GetMapping("/mainpage/kosdaq")
+	public BaseResponse<IndexOfStockDto> getStockIndexKosdaq() {
+		return new BaseResponse<>(chartService.getIndexOfStockByIscd(StockIndex.KOSDAQ));
 	}
 }

--- a/src/main/java/study/chartservice/common/KisUrls.java
+++ b/src/main/java/study/chartservice/common/KisUrls.java
@@ -7,6 +7,7 @@ public enum KisUrls {
 	BASE_URL("https://openapi.koreainvestment.com:9443"),
 	TOKEN_PATH("/oauth2/tokenP"),
 	ITEM_CHART_PRICE_PATH("/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice"),
+	ITEM_CHART_PRICE_TIME_PATH("/uapi/domestic-stock/v1/quotations/inquire-time-itemchartprice"),
 	STOCK_PRICE_INVESTOR_PATH("/uapi/domestic-stock/v1/quotations/inquire-investor"),
 	STOCK_FLUCTUATION_RANK_PATH("/uapi/domestic-stock/v1/ranking/fluctuation");
 

--- a/src/main/java/study/chartservice/common/KisUrls.java
+++ b/src/main/java/study/chartservice/common/KisUrls.java
@@ -9,7 +9,8 @@ public enum KisUrls {
 	ITEM_CHART_PRICE_PATH("/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice"),
 	ITEM_CHART_PRICE_TIME_PATH("/uapi/domestic-stock/v1/quotations/inquire-time-itemchartprice"),
 	STOCK_PRICE_INVESTOR_PATH("/uapi/domestic-stock/v1/quotations/inquire-investor"),
-	STOCK_FLUCTUATION_RANK_PATH("/uapi/domestic-stock/v1/ranking/fluctuation");
+	STOCK_FLUCTUATION_RANK_PATH("/uapi/domestic-stock/v1/ranking/fluctuation"),
+	STOCK_PRICE_INDEX_PATH("/uapi/domestic-stock/v1/quotations/inquire-index-price");
 
 	private final String path;
 

--- a/src/main/java/study/chartservice/common/StockIndex.java
+++ b/src/main/java/study/chartservice/common/StockIndex.java
@@ -1,0 +1,15 @@
+package study.chartservice.common;
+
+import lombok.Getter;
+
+@Getter
+public enum StockIndex {
+	KOSPI("0001"),
+	KOSDAQ("1001");
+
+	private final String value;
+
+	StockIndex(String value) {
+		this.value = value;
+	}
+}

--- a/src/main/java/study/chartservice/global/common/response/BaseResponseCode.java
+++ b/src/main/java/study/chartservice/global/common/response/BaseResponseCode.java
@@ -39,7 +39,8 @@ public enum BaseResponseCode {
 
 	STOCK_NAME_NOT_FOUND(HttpStatus.BAD_REQUEST, false, 6000, "종목 이름 조회 실패"),
 	INVESTOR_NOT_FOUND(HttpStatus.BAD_REQUEST, false, 6001, "투자자 비율 조회 실패"),
-	FLUCTUATION_RANK_NOT_FOUND(HttpStatus.BAD_REQUEST, false, 6002, "등락률 순위 조회 실패");
+	FLUCTUATION_RANK_NOT_FOUND(HttpStatus.BAD_REQUEST, false, 6002, "등락률 순위 조회 실패"),
+	MIN_OF_STOCK_NOT_FOUND(HttpStatus.BAD_REQUEST, false, 6003, "분봉 조회 실패");
 
 	private final HttpStatus httpStatus;
 	private final boolean isSuccess;

--- a/src/main/java/study/chartservice/global/common/response/BaseResponseCode.java
+++ b/src/main/java/study/chartservice/global/common/response/BaseResponseCode.java
@@ -40,7 +40,8 @@ public enum BaseResponseCode {
 	STOCK_NAME_NOT_FOUND(HttpStatus.BAD_REQUEST, false, 6000, "종목 이름 조회 실패"),
 	INVESTOR_NOT_FOUND(HttpStatus.BAD_REQUEST, false, 6001, "투자자 비율 조회 실패"),
 	FLUCTUATION_RANK_NOT_FOUND(HttpStatus.BAD_REQUEST, false, 6002, "등락률 순위 조회 실패"),
-	MIN_OF_STOCK_NOT_FOUND(HttpStatus.BAD_REQUEST, false, 6003, "분봉 조회 실패");
+	MIN_OF_STOCK_NOT_FOUND(HttpStatus.BAD_REQUEST, false, 6003, "분봉 조회 실패"),
+	STOCK_INDEX_NOT_FOUND(HttpStatus.BAD_REQUEST, false, 6004, "주식 지수 조회 실패");
 
 	private final HttpStatus httpStatus;
 	private final boolean isSuccess;

--- a/src/main/java/study/chartservice/kis/application/KisSchedulerService.java
+++ b/src/main/java/study/chartservice/kis/application/KisSchedulerService.java
@@ -8,6 +8,6 @@ public interface KisSchedulerService {
 	void collectKisDataOfYear();
 	void collectInvestor();
 	void collectFluctuationRank();
-
+	void collectKisDataOfIndex();
 
 }

--- a/src/main/java/study/chartservice/kis/application/KisSchedulerService.java
+++ b/src/main/java/study/chartservice/kis/application/KisSchedulerService.java
@@ -1,10 +1,13 @@
 package study.chartservice.kis.application;
 
 public interface KisSchedulerService {
+	void collectKisDatOfTime();
 	void collectKisDataOfDay();
 	void collectKisDataOfWeek();
 	void collectKisDataOfMonth();
 	void collectKisDataOfYear();
 	void collectInvestor();
 	void collectFluctuationRank();
+
+
 }

--- a/src/main/java/study/chartservice/kis/dto/resp/IndexDataDto.java
+++ b/src/main/java/study/chartservice/kis/dto/resp/IndexDataDto.java
@@ -1,0 +1,43 @@
+package study.chartservice.kis.dto.resp;
+
+import lombok.Getter;
+
+@Getter
+public class IndexDataDto {
+	private String bstp_nmix_prpr;
+	private String bstp_nmix_prdy_vrss;
+	private String prdy_vrss_sign;
+	private String bstp_nmix_prdy_ctrt;
+	private String acml_vol;
+	private String prdy_vol;
+	private String acml_tr_pbmn;
+	private String prdy_tr_pbmn;
+	private String bstp_nmix_oprc;
+	private String prdy_nmix_vrss_nmix_oprc;
+	private String oprc_vrss_prpr_sign;
+	private String bstp_nmix_oprc_prdy_ctrt;
+	private String bstp_nmix_hgpr;
+	private String prdy_nmix_vrss_nmix_hgpr;
+	private String hgpr_vrss_prpr_sign;
+	private String bstp_nmix_hgpr_prdy_ctrt;
+	private String bstp_nmix_lwpr;
+	private String prdy_clpr_vrss_lwpr;
+	private String lwpr_vrss_prpr_sign;
+	private String prdy_clpr_vrss_lwpr_rate;
+	private String ascn_issu_cnt;
+	private String uplm_issu_cnt;
+	private String stnr_issu_cnt;
+	private String down_issu_cnt;
+	private String lslm_issu_cnt;
+	private String dryy_bstp_nmix_hgpr;
+	private String dryy_hgpr_vrss_prpr_rate;
+	private String dryy_bstp_nmix_hgpr_date;
+	private String dryy_bstp_nmix_lwpr;
+	private String dryy_lwpr_vrss_prpr_rate;
+	private String dryy_bstp_nmix_lwpr_date;
+	private String total_askp_rsqn;
+	private String total_bidp_rsqn;
+	private String seln_rsqn_rate;
+	private String shnu_rsqn_rate;
+	private String ntby_rsqn;
+}

--- a/src/main/java/study/chartservice/kis/dto/resp/StockTimeDataDto.java
+++ b/src/main/java/study/chartservice/kis/dto/resp/StockTimeDataDto.java
@@ -1,0 +1,15 @@
+package study.chartservice.kis.dto.resp;
+
+import lombok.Getter;
+
+@Getter
+public class StockTimeDataDto {
+	private String stck_bsop_date;
+	private String stck_cntg_hour;
+	private String acml_tr_pbmn;
+	private String stck_prpr;
+	private String stck_oprc;
+	private String stck_hgpr;
+	private String stck_lwpr;
+	private String cntg_vol;
+}


### PR DESCRIPTION
<!-- 제목 : convention: 기능명#issue 번호
  ex) feat : pull request template#17-->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리펙토링
- [ ] 간단 코드 리펙토링 (주석, 코드 컨벤션, 오타 수정 등)
- [ ] 패키징 구조 변경
- [ ] 파일명 변경
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용

<!--@{Issue번호} + Enter
ex) @17
이슈와 PR 연결을 위해 사용합니다!-->
#19 
- 30분 단위로 종목에 대한 가격 데이터 저장 및 조회 기능 완료 
- 30분 단위로 종목 지수 (코스피, 코스닥)에 대한 가격 데이터 저장 및 조회 기능 완료 

  <br/>

## 🔧 앞으로의 과제
- [ ] 스케쥴러 실행 중 예외 발생시 재실행 기능 구현하기 

