### PR TITLE
refactor: 한국 투자증권 API 호출 시 접근 토큰 여러번 조회 하지 않도록 수정#31

### DIFF
--- a/src/main/java/study/chartservice/kis/application/KisApiService.java
+++ b/src/main/java/study/chartservice/kis/application/KisApiService.java
@@ -1,10 +1,9 @@
 package study.chartservice.kis.application;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import study.chartservice.kis.domain.KisAccessToken;
 
 // 한국투자증권 API 서비스
 public interface KisApiService {
 
-	KisAccessToken getKisAccessToken() throws JsonProcessingException;
+	KisAccessToken getKisAccessToken();
 }

--- a/src/main/java/study/chartservice/kis/application/KisApiServiceImp.java
+++ b/src/main/java/study/chartservice/kis/application/KisApiServiceImp.java
@@ -34,44 +34,52 @@ public class KisApiServiceImp implements KisApiService {
 	private String appSecret;
 
 	@Override
-	public KisAccessToken getKisAccessToken() throws JsonProcessingException {
-		log.info("토큰 테스트");
-		String token = redisTemplate.opsForValue().get("kisAccessToken");
+	public KisAccessToken getKisAccessToken() {
+		try {
+			log.info("토큰 테스트");
 
-		log.info("token: {}", token);
-		log.info("token status: {}", token == null);
+			String token = redisTemplate.opsForValue().get("kisAccessToken");
 
-		return token == null ? createKisAccessToken() : objectMapper.readValue(
-				token, KisAccessToken.class);
+			log.info("token: {}", token);
+			log.info("token status: {}", token == null);
+
+			return token == null ? createKisAccessToken() : objectMapper.readValue(
+					token, KisAccessToken.class);
+		}catch (Exception e) {
+			throw new RuntimeException();
+		}
 	}
-	private KisAccessToken createKisAccessToken() throws JsonProcessingException {
+	private KisAccessToken createKisAccessToken() {
 		// Request Body 설정
 		Map<String, String> body = new HashMap<>();
 		body.put("grant_type", "client_credentials");
 		body.put("appkey", appKey);
 		body.put("appsecret", appSecret);
 
-		// Request Body JSON 변환
-		String jsonBody = objectMapper.writeValueAsString(body);
+		try {
+			// Request Body JSON 변환
+			String jsonBody = objectMapper.writeValueAsString(body);
 
-		// RestTemplate 을 이용한 POST 통신
-		ResponseEntity<String> response = restTemplate.exchange(
-				KisUrls.TOKEN_PATH.getFullUrl(),
-				HttpMethod.POST,
-				new HttpEntity<>(jsonBody, null),
-				String.class);
+			// RestTemplate 을 이용한 POST 통신
+			ResponseEntity<String> response = restTemplate.exchange(
+					KisUrls.TOKEN_PATH.getFullUrl(),
+					HttpMethod.POST,
+					new HttpEntity<>(jsonBody, null),
+					String.class);
 
-		// Response Body JSON 변환
-		KisAccessToken kisAccessToken = objectMapper.readValue(response.getBody(),
-				KisAccessToken.class);
+			// Response Body JSON 변환
+			KisAccessToken kisAccessToken = objectMapper.readValue(response.getBody(),
+					KisAccessToken.class);
 
-		// 토큰 시간(86400초 - 3600초(1시간)) 지정 후 Redis 에 토큰 저장
-		redisTemplate.opsForValue()
-				.set("kisAccessToken", objectMapper.writeValueAsString(kisAccessToken),
-						Long.parseLong(kisAccessToken.getExpires_in()) - ONE_HOUR_TO_SECONDS,
-						TimeUnit.SECONDS);
+			// 토큰 시간(86400초 - 3600초(1시간)) 지정 후 Redis 에 토큰 저장
+			redisTemplate.opsForValue()
+					.set("kisAccessToken", objectMapper.writeValueAsString(kisAccessToken),
+							Long.parseLong(kisAccessToken.getExpires_in()) - ONE_HOUR_TO_SECONDS,
+							TimeUnit.SECONDS);
 
-		return kisAccessToken;
+			return kisAccessToken;
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(e);
+		}
 	}
-
 }


### PR DESCRIPTION
<!-- 제목 : convention: 기능명#issue 번호
  ex) feat : pull request template#17-->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## ✔️PR Type
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 주요 코드 리펙토링
- [ ] 간단 코드 리펙토링 (주석, 코드 컨벤션, 오타 수정 등)
- [ ] 패키징 구조 변경
- [ ] 파일명 변경
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용

<!--@{Issue번호} + Enter
ex) @17
이슈와 PR 연결을 위해 사용합니다!-->

#31 
- 수정 전 한투 증권 API 호출을 위한 AccessToken 값이 불필요하게 여러번 호출되어 사용됨 
- 이 부분을 수정해서 한번만 AccessToken을 호출하도록 수정하였습니다.

